### PR TITLE
Update Preprocessing_and_Embeddings.ipynb

### DIFF
--- a/preprocessing_and_embeddings/Preprocessing_and_Embeddings.ipynb
+++ b/preprocessing_and_embeddings/Preprocessing_and_Embeddings.ipynb
@@ -226,7 +226,7 @@
    "source": [
     "w2v_model = Word2Vec(min_count=3,\n",
     "                     window=4,\n",
-    "                     size=300,\n",
+    "                     vector_size=300,\n",
     "                     sample=1e-5, \n",
     "                     alpha=0.03, \n",
     "                     min_alpha=0.0007, \n",


### PR DESCRIPTION
Following Major Major precious [Stack Overflow suggestion ](https://stackoverflow.com/a/67080756/15488129) ,
I propose to update w2v_model variable so that the notebook could work also on conda 4.10.3 (which actually uses Python 3.8.8)

Otherwise it would return TypeError as shown below.
<img width="595" alt="Immagine 2021-10-28 161624" src="https://user-images.githubusercontent.com/58935223/139274530-3047a43c-1f2a-419c-9e08-686dc94d0d2c.png">

