### PR TITLE
Update KMeans_clustering.ipynb

### DIFF
--- a/KMeans_clustering/KMeans_clustering.ipynb
+++ b/KMeans_clustering/KMeans_clustering.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "words = pd.DataFrame(word_vectors.vocab.keys())\n",
+    "words = pd.DataFrame(word_vectors.vocab.index_to_key)\n",
     "words.columns = ['words']\n",
     "words['vectors'] = words.words.apply(lambda x: word_vectors[f'{x}'])\n",
     "words['cluster'] = words.vectors.apply(lambda x: model.predict([np.array(x)]))\n",


### PR DESCRIPTION
To avoid AttributeError generated by new version of Gensim.


The vocab attribute was removed from KeyedVector in Gensim 4.0.0.
Use KeyedVector's .key_to_index dict, .index_to_key list, and methods .get_vecattr(key, attr) and .set_vecattr(key, attr, new_val) instead.
See https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4